### PR TITLE
feat: Add authoritative IAM policy support for secrets manager

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,14 @@ variable "project_id" {
 }
 
 variable "secrets" {
-  type        = list(map(string))
+  type = list(object({
+    name                  = string
+    next_rotation_time    = optional(string)
+    rotation_period       = optional(string)
+    automatic_replication = optional(bool)
+    secret_data           = string
+    iam_roles             = optional(map(list(string)))
+  }))
   description = "The list of the secrets"
   default     = []
 }

--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.3.0"
   required_providers {
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
I've also employed optional attributes on the type constraints for the secrets object. This required bumping the required Terraform version to greater than v1.3.0.