### PR TITLE
support for google provider's `is_secret_data_base64`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,10 @@ resource "google_secret_manager_secret" "secrets" {
   for_each  = { for secret in var.secrets : secret.name => secret }
   secret_id = each.value.name
   replication {
-    automatic = lookup(each.value, "automatic_replication", null) != null ? true : null
+    dynamic "auto" {
+      for_each = lookup(each.value, "automatic_replication", null) != null ? [1] : []
+      content {}
+    } 
     dynamic "user_managed" {
       for_each = lookup(var.user_managed_replication, each.key, null) != null ? [1] : []
       content {

--- a/main.tf
+++ b/main.tf
@@ -84,4 +84,5 @@ resource "google_secret_manager_secret_version" "secret-version" {
   for_each    = { for secret in var.secrets : secret.name => secret }
   secret      = google_secret_manager_secret.secrets[each.value.name].id
   secret_data = each.value.secret_data
+  is_secret_data_base64 = lookup(each.value, "is_secret_data_base64", false)
 }

--- a/versions.tf
+++ b/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.0.0, < 5.0"
+      version = ">= 4.84, < 5.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.0.0, < 5.0"
+      version = ">= 4.84, < 5.0"
     }
   }
 


### PR DESCRIPTION
* add support for `is_secret_data_base64` from latest provider's release
* set provider's requirement >= 4.84
* update `automatic_replication` to the new `auto {}`  block syntax