### PR TITLE
fix: Update deprecated 'automatic_replication' attribute to 'auto'

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "google_secret_manager_secret" "secrets" {
   for_each  = { for secret in var.secrets : secret.name => secret }
   secret_id = each.value.name
   replication {
-    automatic = lookup(each.value, "automatic_replication", null) != null ? true : null
+    auto = lookup(each.value, "auto_replication", null) != null ? true : null
     dynamic "user_managed" {
       for_each = lookup(var.user_managed_replication, each.key, null) != null ? [1] : []
       content {

--- a/versions.tf
+++ b/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.0.0, < 5.0"
+      version = ">= 4.0.0, < 6.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.0.0, < 5.0"
+      version = ">= 4.0.0, < 6.0"
     }
   }
 


### PR DESCRIPTION
Fixed a warning:

```
Warning: Argument is deprecated

  with module.secret-manager.google_secret_manager_secret.secrets["talana-dev-main-us-central1-gke-cert-manager"],
  on .terraform/modules/secret-manager/main.tf line 44, in resource "google_secret_manager_secret" "secrets":
  44:     automatic = lookup(each.value, "automatic_replication", null) != null ? true : null

automatic is deprecated and will be removed in a future major release. We should use auto instead.
```

This PR updates the code to use `auto` in order to address the deprecation warning.
