### PR TITLE
fix(TPG>=5)!: Adapt to breaking change in secret_manager_secret resource

### DIFF
--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source  = "hashicorp/google"
+      source = "hashicorp/google"
     }
   }
   required_version = ">= 0.13"

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -18,7 +18,6 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
     }
   }
   required_version = ">= 0.13"

--- a/main.tf
+++ b/main.tf
@@ -42,10 +42,10 @@ resource "google_secret_manager_secret" "secrets" {
   secret_id = each.value.name
   replication {
     dynamic "user_managed" {
-      for_each = lookup(var.user_managed_replication, each.key, null) != null ? [1] : []
+      for_each = lookup(var.user_managed_replication, each.key, null) != null ? [lookup(var.user_managed_replication, each.key, {})] : [{}]
       content {
         dynamic "replicas" {
-          for_each = lookup(var.user_managed_replication, each.key, [])
+          for_each = user_managed.value != {} ? [user_managed.value] : []
           content {
             location = replicas.value.location
             dynamic "customer_managed_encryption" {
@@ -59,6 +59,7 @@ resource "google_secret_manager_secret" "secrets" {
       }
     }
   }
+
   labels = lookup(var.labels, each.key, null)
   dynamic "topics" {
     for_each = lookup(var.topics, each.key, [])

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,6 @@ resource "google_secret_manager_secret" "secrets" {
   for_each  = { for secret in var.secrets : secret.name => secret }
   secret_id = each.value.name
   replication {
-    automatic = lookup(each.value, "automatic_replication", null) != null ? true : null
     dynamic "user_managed" {
       for_each = lookup(var.user_managed_replication, each.key, null) != null ? [1] : []
       content {

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.1"
+      version = ">= 4.1"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.3"
+      version = ">= 4.3"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.0.0, < 5.0"
+      version = ">= 4.0.0, < 6"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.0.0, < 5.0"
+      version = ">= 4.0.0, < 6"
     }
   }
 


### PR DESCRIPTION

This Pull Request incorporates the necessary changes to ensure compatibility with version 5.0.0 of the Terraform Google Provider. Specifically, the following adaptations have been made:

- Removed the reference to the automatic field in the google_secret_manager_secret resource, which was deprecated in TPG v5.0.0.

- Included the proposed changes from https://github.com/GoogleCloudPlatform/terraform-google-secret-manager/pull/34.

These modifications will allow us to continue utilizing our Terraform configurations seamlessly following the breaking change introduced in TPG v5.0.0.

I would appreciate a review and feedback on the changes made.