### PR TITLE
fix: google_secret_manager_secret_iam_binding.binding for_each

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -98,8 +98,8 @@ resource "google_secret_manager_secret_version" "secret-version" {
 
 resource "google_secret_manager_secret_iam_binding" "binding" {
   project   = var.project_id
-  for_each  = { for secret in google_secret_manager_secret.secrets : secret.name => secret if length(var.secret_accessors_list) > 0 }
-  secret_id = each.value.name
+  for_each  = { for secret in var.secrets : secret.name => secret if length(var.secret_accessors_list) > 0 }
+  secret_id = google_secret_manager_secret.secrets[each.value.name].id
   role      = "roles/secretmanager.secretAccessor"
   members   = var.secret_accessors_list
 }


### PR DESCRIPTION
Fixed a warning:

```bash
╷
│ Error: Invalid for_each argument
│ 
│   on ../modules/secret-manager/main.tf line 101, in resource "google_secret_manager_secret_iam_binding" "binding":
│  101:   for_each  = { for secret in google_secret_manager_secret.secrets : secret.name => secret if length(var.secret_accessors_list) > 0 }
│     ├────────────────
│     │ google_secret_manager_secret.secrets is object with 1 attribute "hogehoge"
│     │ var.secret_accessors_list is list of string with 1 element
│ 
│ The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this resource.
│ 
│ When working with unknown values in for_each, it's better to define the map keys statically in your configuration and place apply-time results only in the map values.
│ 
│ Alternatively, you could use the -target planning option to first apply only the resources that the for_each value depends on, and then apply a second time to fully converge.
```