### PR TITLE
fix!: Fix handling the CMEK with automatic replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Functional examples are included in the [examples](./examples/) directory.
 |------|-------------|------|---------|:--------:|
 | add\_kms\_permissions | The list of the crypto keys to give secret manager access to | `list(string)` | `[]` | no |
 | add\_pubsub\_permissions | The list of the pubsub topics to give secret manager access to | `list(string)` | `[]` | no |
-| automatic\_replication | Automatic replication parameters that will be used for defined secrets | `map(list(object({ kms_key_name = string })))` | `{}` | no |
+| automatic\_replication | Automatic replication parameters that will be used for defined secrets. If not provided, the secret will be automatically replicated using Google-managed key without any restrictions. | `map(object({ kms_key_name = string }))` | `{}` | no |
 | labels | labels to be added for the defined secrets | `map(map(string))` | `{}` | no |
 | project\_id | The project ID to manage the Secret Manager resources | `string` | n/a | yes |
 | secret\_accessors\_list | The list of the members to allow accessing secrets | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ module "secret-manager" {
       secret_data              = "secret information"
     },
   ]
-  automatic_replication = {}
 }
 ```
 

--- a/examples/multiple/main.tf
+++ b/examples/multiple/main.tf
@@ -62,8 +62,8 @@ module "secret-manager" {
       secret_data        = "my_secret"
     },
     {
-      name                  = "secret-2"
-      secret_data           = "my_secret2"
+      name        = "secret-2"
+      secret_data = "my_secret2"
     },
     {
       name        = "secret-3"
@@ -71,7 +71,9 @@ module "secret-manager" {
     }
   ]
   automatic_replication = {
-    secret-2 = []
+    secret-2 = {
+      kms_key_name = google_kms_crypto_key.crypto_key_east.id
+    }
   }
   user_managed_replication = {
     secret-multi-1 = [

--- a/examples/multiple/main.tf
+++ b/examples/multiple/main.tf
@@ -123,7 +123,8 @@ module "secret-manager" {
   }
   add_kms_permissions = [
     google_kms_crypto_key.crypto_key_east.id,
-    google_kms_crypto_key.crypto_key_central.id
+    google_kms_crypto_key.crypto_key_central.id,
+    google_kms_crypto_key.crypto_key_global.id
   ]
   add_pubsub_permissions = [
     google_pubsub_topic.secret_topic_1.id,

--- a/examples/multiple/main.tf
+++ b/examples/multiple/main.tf
@@ -17,6 +17,18 @@
 resource "random_id" "random_suffix" {
   byte_length = 2
 }
+
+resource "google_kms_key_ring" "key_ring_global" {
+  name     = "key-ring-east-${random_id.random_suffix.hex}"
+  location = "global"
+  project  = var.project_id
+}
+
+resource "google_kms_crypto_key" "crypto_key_global" {
+  name     = "crypto-key-${random_id.random_suffix.hex}"
+  key_ring = google_kms_key_ring.key_ring_global.id
+}
+
 resource "google_kms_key_ring" "key_ring_east" {
   name     = "key-ring-east-${random_id.random_suffix.hex}"
   location = "us-east1"
@@ -72,7 +84,7 @@ module "secret-manager" {
   ]
   automatic_replication = {
     secret-2 = {
-      kms_key_name = google_kms_crypto_key.crypto_key_east.id
+      kms_key_name = google_kms_crypto_key.crypto_key_global.id
     }
   }
   user_managed_replication = {

--- a/examples/pubsub/main.tf
+++ b/examples/pubsub/main.tf
@@ -43,10 +43,10 @@ module "secret-manager" {
   project_id = var.project_id
   secrets = [
     {
-      name                  = "secret-pubsub-1"
-      next_rotation_time    = "2024-10-02T15:01:23Z"
-      rotation_period       = "31536000s"
-      secret_data           = "secret information"
+      name               = "secret-pubsub-1"
+      next_rotation_time = "2024-10-02T15:01:23Z"
+      rotation_period    = "31536000s"
+      secret_data        = "secret information"
     },
   ]
   topics = {
@@ -59,5 +59,4 @@ module "secret-manager" {
   depends_on = [
     google_pubsub_topic_iam_member.sm_sa_publisher
   ]
-  automatic_replication = {}
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -25,9 +25,8 @@ module "secret-manager" {
   project_id = var.project_id
   secrets = [
     {
-      name                  = "secret-1"
-      secret_data           = "secret information"
+      name        = "secret-1"
+      secret_data = "secret information"
     },
   ]
-  automatic_replication = {}
 }

--- a/main.tf
+++ b/main.tf
@@ -42,12 +42,12 @@ resource "google_secret_manager_secret" "secrets" {
   secret_id = each.value.name
   replication {
     dynamic "auto" {
-      for_each = (try(var.automatic_replication, {}) != null && lookup(var.user_managed_replication, each.key, null) == null) ? [1] : []
+      for_each = lookup(var.user_managed_replication, each.key, null) == null ? [1] : []
       content {
         dynamic "customer_managed_encryption" {
-          for_each = lookup(var.automatic_replication, "kms_key_name", null) != null ? [1] : []
+          for_each = try(var.automatic_replication[each.key].kms_key_name, null) != null ? [var.automatic_replication[each.key].kms_key_name] : []
           content {
-            kms_key_name = each.value.kms_key_name
+            kms_key_name = customer_managed_encryption.value
           }
         }
       }

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "user_managed_replication" {
 
 variable "automatic_replication" {
   type        = map(object({ kms_key_name = string }))
-  description = "Automatic replication parameters that will be used for defined secrets"
+  description = "Automatic replication parameters that will be used for defined secrets. If not provided, the secret will be automatically replicated using Google-managed key without any restrictions."
   default     = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -32,7 +32,7 @@ variable "user_managed_replication" {
 }
 
 variable "automatic_replication" {
-  type        = map(list(object({ kms_key_name = string })))
+  type        = map(object({ kms_key_name = string }))
   description = "Automatic replication parameters that will be used for defined secrets"
   default     = {}
 }


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/terraform-google-secret-manager/issues/73

## Changes
- Fixed the conditions for `auto / customer_managed_encryption` dynamic blocks, so the value of `kms_key_name` is properly passed to the resource `google_secret_manager_secret `
- BREAKING CHANGE: Changed the type of `automatic_replication` variable, removing the redundant `list()` nesting level. There could be only one `auto {...}` block in `replication`,
- Removed `automatic_replication = {}` from example, since that it a default value and it could be omitted,

## Example

```hcl
# main.tf

module "secret-manager" {
  source = "../../"

  project_id = var.project_id
  secrets = [{
    name        = "secret-1"
    secret_data = "secret information"
  }]
  automatic_replication = {
    secret-1 = {     # <= Now the type is `map(object(...))` instead of `map(list(object(...)))`
      kms_key_name = "projects/my-project/locations/global/keyRings/key-ring-1/cryptoKeys/crypto-key-1"
    }
  }
}
```

### Result

```shell
$ terraform plan

  # module.secret-manager.google_secret_manager_secret.secrets["secret-1"] will be created
  + resource "google_secret_manager_secret" "secrets" {
      + create_time           = (known after apply)
      + effective_annotations = (known after apply)
      + effective_labels      = (known after apply)
      + expire_time           = (known after apply)
      + id                    = (known after apply)
      + name                  = (known after apply)
      + project               = "<my-project>"
      + secret_id             = "secret-1"
      + terraform_labels      = (known after apply)

      + replication {
          + auto {
              + customer_managed_encryption {
                  + kms_key_name = "projects/my-project/locations/global/keyRings/key-ring-1/cryptoKeys/crypto-key-1"
                }
            }
        }
    }
```