### PR TITLE
feat!: Change variable type for secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ docker_test_lint:
 .PHONY: docker_generate_docs
 docker_generate_docs:
 	docker run --rm -it \
+	  -e ENABLE_BPMETADATA \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs'

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Functional examples are included in the [examples](./examples/) directory.
 | labels | labels to be added for the defined secrets | `map(map(string))` | `{}` | no |
 | project\_id | The project ID to manage the Secret Manager resources | `string` | n/a | yes |
 | secret\_accessors\_list | The list of the members to allow accessing secrets | `list(string)` | `[]` | no |
-| secrets | The list of the secrets | `list(map(string))` | `[]` | no |
+| secrets | The list of the secrets | <pre>list(object({<br>    name : string,<br>    secret_data : optional(string),<br>    next_rotation_time : optional(string),<br>    rotation_period : optional(string),<br>    create_version : optional(bool, true)<br>  }))</pre> | `[]` | no |
 | topics | topics that will be used for defined secrets | `map(list(object({ name = string })))` | `{}` | no |
 | user\_managed\_replication | Replication parameters that will be used for defined secrets | `map(list(object({ location = string, kms_key_name = string })))` | `{}` | no |
 

--- a/docs/upgrading_to_secret_manager_v0.4.0_from_v0.3.0.md
+++ b/docs/upgrading_to_secret_manager_v0.4.0_from_v0.3.0.md
@@ -1,0 +1,27 @@
+# Upgrading to Secret Manager v0.4.0 from v0.3.0 
+The v0.4.0 release is backward incompatible release.
+
+## Impact
+Secret version creation is optional in Secret Manager module. In the release 
+v0.3.0, the secret version creation was dependent on the presence of secret_data
+in the input variable.
+In the release v0.4.0, the secret version creation is dependent on the `create_version`
+flag in the input data.
+
+```diff
+module "secret-manager" {
+  source  = "GoogleCloudPlatform/secret-manager/google"
+  version = "~> 0.3"
+
+  project_id = var.project_id
+  secrets = [
+    {
+      name           = "secret-1"
++     create_version = false
+    },
+  ]
+}
+```
+
+All the users who don't want secret-version to be created needs to set `create_version` to false explicitly.
+

--- a/docs/upgrading_to_secret_manager_v0.4.0_from_v0.3.0.md
+++ b/docs/upgrading_to_secret_manager_v0.4.0_from_v0.3.0.md
@@ -1,8 +1,8 @@
-# Upgrading to Secret Manager v0.4.0 from v0.3.0 
+# Upgrading to Secret Manager v0.4.0 from v0.3.0
 The v0.4.0 release is backward incompatible release.
 
 ## Impact
-Secret version creation is optional in Secret Manager module. In the release 
+Secret version creation is optional in Secret Manager module. In the release
 v0.3.0, the secret version creation was dependent on the presence of secret_data
 in the input variable.
 In the release v0.4.0, the secret version creation is dependent on the `create_version`

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "google_secret_manager_secret" "secrets" {
 }
 
 resource "google_secret_manager_secret_version" "secret-version" {
-  for_each    = { for secret in var.secrets : secret.name => secret if can(secret.secret_data) }
+  for_each    = { for secret in var.secrets : secret.name => secret if can(secret.create_version) }
   secret      = google_secret_manager_secret.secrets[each.value.name].id
   secret_data = each.value.secret_data
 }

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "google_secret_manager_secret" "secrets" {
 }
 
 resource "google_secret_manager_secret_version" "secret-version" {
-  for_each    = { for secret in var.secrets : secret.name => secret if can(secret.create_version) }
+  for_each    = { for secret in var.secrets : secret.name => secret if secret.create_version }
   secret      = google_secret_manager_secret.secrets[each.value.name].id
   secret_data = each.value.secret_data
 }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -19,71 +5,85 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 spec:
-  title: terraform-google-secret-manager
-  source:
-    repo: https://github.com/GoogleCloudPlatform/terraform-google-secret-manager.git
-    sourceType: git
-  version: 0.3.0
-  actuationTool:
-    type: Terraform
-    version: '>= 0.13'
-  examples:
-  - name: kms
-    location: examples/kms
-  - name: multiple
-    location: examples/multiple
-  - name: pubsub
-    location: examples/pubsub
-  - name: simple
-    location: examples/simple
-  variables:
-  - name: add_kms_permissions
-    description: The list of the crypto keys to give secret manager access to
-    type: list(string)
-    default: []
-    required: false
-  - name: add_pubsub_permissions
-    description: The list of the pubsub topics to give secret manager access to
-    type: list(string)
-    default: []
-    required: false
-  - name: labels
-    description: labels to be added for the defined secrets
-    type: map(map(string))
-    default: {}
-    required: false
-  - name: project_id
-    description: The project ID to manage the Secret Manager resources
-    type: string
-    required: true
-  - name: secrets
-    description: The list of the secrets
-    type: list(map(string))
-    default: []
-    required: false
-  - name: topics
-    description: topics that will be used for defined secrets
-    type: map(list(object({ name = string })))
-    default: {}
-    required: false
-  - name: user_managed_replication
-    description: Replication parameters that will be used for defined secrets
-    type: map(list(object({ location = string, kms_key_name = string })))
-    default: {}
-    required: false
-  outputs:
-  - name: secret_names
-    description: The name list of Secrets
-  - name: secret_versions
-    description: The name list of Secret Versions
-  roles:
-  - level: Project
+  info:
+    title: terraform-google-secret-manager
+    source:
+      repo: https://github.com/GoogleCloudPlatform/terraform-google-secret-manager.git
+      sourceType: git
+    version: 1.0.0
+    actuationTool:
+      flavor: Terraform
+      version: ">= 0.13"
+    description: {}
+  content:
+    examples:
+      - name: kms
+        location: examples/kms
+      - name: multiple
+        location: examples/multiple
+      - name: pubsub
+        location: examples/pubsub
+      - name: simple
+        location: examples/simple
+  interfaces:
+    variables:
+      - name: add_kms_permissions
+        description: The list of the crypto keys to give secret manager access to
+        varType: list(string)
+        defaultValue: []
+      - name: add_pubsub_permissions
+        description: The list of the pubsub topics to give secret manager access to
+        varType: list(string)
+        defaultValue: []
+      - name: automatic_replication
+        description: Automatic replication parameters that will be used for defined secrets. If not provided, the secret will be automatically replicated using Google-managed key without any restrictions.
+        varType: map(object({ kms_key_name = string }))
+        defaultValue: {}
+      - name: labels
+        description: labels to be added for the defined secrets
+        varType: map(map(string))
+        defaultValue: {}
+      - name: project_id
+        description: The project ID to manage the Secret Manager resources
+        varType: string
+        required: true
+      - name: secret_accessors_list
+        description: The list of the members to allow accessing secrets
+        varType: list(string)
+        defaultValue: []
+      - name: secrets
+        description: The list of the secrets
+        varType: |-
+          list(object({
+              name : string,
+              secret_data : optional(string),
+              next_rotation_time : optional(string),
+              rotation_period : optional(string),
+              create_version : optional(bool, true)
+            }))
+        defaultValue: []
+      - name: topics
+        description: topics that will be used for defined secrets
+        varType: map(list(object({ name = string })))
+        defaultValue: {}
+      - name: user_managed_replication
+        description: Replication parameters that will be used for defined secrets
+        varType: map(list(object({ location = string, kms_key_name = string })))
+        defaultValue: {}
+    outputs:
+      - name: secret_names
+        description: The name list of Secrets
+      - name: secret_versions
+        description: The name list of Secret Versions
+  requirements:
     roles:
-    - roles/owner
-  services:
-  - cloudresourcemanager.googleapis.com
-  - storage-api.googleapis.com
-  - serviceusage.googleapis.com
-  - secretmanager.googleapis.com
-  - pubsub.googleapis.com
-  - cloudkms.googleapis.com
+      - level: Project
+        roles:
+          - roles/owner
+    services:
+      - cloudresourcemanager.googleapis.com
+      - storage-api.googleapis.com
+      - serviceusage.googleapis.com
+      - secretmanager.googleapis.com
+      - pubsub.googleapis.com
+      - cloudkms.googleapis.com

--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,13 @@ variable "project_id" {
 }
 
 variable "secrets" {
-  type        = list(map(string))
+  type = list(object({
+    name : string,
+    secret_data : optional(string),
+    next_rotation_time : optional(string),
+    rotation_period : optional(string),
+    create_version : optional(bool, true)
+  }))
   description = "The list of the secrets"
   default     = []
 }

--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
   required_providers {
     google = {
       source  = "hashicorp/google"
@@ -28,6 +28,6 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/secret-manager/v1.0.0"
+    module_name = "blueprints/terraform/secret-manager/v0.3.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -28,6 +28,6 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/secret-manager/v0.3.0"
+    module_name = "blueprints/terraform/secret-manager/v1.0.0"
   }
 }


### PR DESCRIPTION
This PR makes below changes,

1. Change type of variable `secrets` from `list(map(string))` to `list(object({})`
2. Create secret-version based on a newly introduced flag called `create_version` (true by default)

https://github.com/GoogleCloudPlatform/terraform-google-secret-manager/issues/88