### PR TITLE
fix: do not create secret version when secret_data is null

### DIFF
--- a/modules/simple-secret/main.tf
+++ b/modules/simple-secret/main.tf
@@ -68,6 +68,7 @@ resource "google_secret_manager_secret" "secret" {
 }
 
 resource "google_secret_manager_secret_version" "version" {
+  count       = var.secret_data != null ? 1 : 0
   secret      = google_secret_manager_secret.secret.id
   secret_data = var.secret_data
 }

--- a/modules/simple-secret/metadata.yaml
+++ b/modules/simple-secret/metadata.yaml
@@ -28,7 +28,7 @@ spec:
     version: 0.5.1
     actuationTool:
       flavor: Terraform
-      version: ">= 0.13"
+      version: ">= 1.3"
     description: {}
   content:
     examples:

--- a/modules/simple-secret/outputs.tf
+++ b/modules/simple-secret/outputs.tf
@@ -26,7 +26,7 @@ output "name" {
 
 output "version" {
   description = "The version of the created secret"
-  value       = google_secret_manager_secret_version.version.name
+  value       = try(google_secret_manager_secret_version.version[0].name, "")
 }
 
 output "project_id" {


### PR DESCRIPTION
* default value for secret_data of module/simple-secret is null
* the secret_version creation fails with default of secret_data as `null` is not allowed
`│ The argument "secret_data" is required, but no definition was found.`
* This PR updates the logic to not create secret_version if the secret_data is null