### PR TITLE
feat: Add per module requirements to secret-manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25.4
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.23
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25.4
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 
@@ -79,7 +79,7 @@ docker_generate_docs:
 	  -e ENABLE_BPMETADATA \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
-		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs'
+		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs --per-module-requirements'
 
 # Alias for backwards compatibility
 .PHONY: generate_docs

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -36,6 +36,8 @@ spec:
     examples:
       - name: kms
         location: examples/kms
+      - name: monitoring-alert
+        location: examples/monitoring-alert
       - name: multiple
         location: examples/multiple
       - name: pubsub
@@ -97,15 +99,11 @@ spec:
       - level: Project
         roles:
           - roles/secretmanager.admin
-          - roles/cloudkms.admin
-          - roles/pubsub.admin
+          - roles/iam.serviceAccountUser
+          - roles/logging.logWriter
     services:
-      - cloudresourcemanager.googleapis.com
-      - storage-api.googleapis.com
-      - serviceusage.googleapis.com
+      - iam.googleapis.com
       - secretmanager.googleapis.com
-      - pubsub.googleapis.com
-      - cloudkms.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 4.83.0, < 7"

--- a/modules/simple-secret/metadata.yaml
+++ b/modules/simple-secret/metadata.yaml
@@ -141,11 +141,13 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/secretmanager.admin
+          - roles/cloudkms.admin
+          - roles/pubsub.admin
           - roles/logging.logWriter
-          - roles/secretmanager.secretAccessor
-          - roles/secretmanager.secretVersionAdder
-          - roles/secretmanager.viewer
     services:
+      - cloudkms.googleapis.com
+      - pubsub.googleapis.com
       - secretmanager.googleapis.com
     providerVersions:
       - source: hashicorp/google

--- a/modules/simple-secret/metadata.yaml
+++ b/modules/simple-secret/metadata.yaml
@@ -34,6 +34,8 @@ spec:
     examples:
       - name: kms
         location: examples/kms
+      - name: monitoring-alert
+        location: examples/monitoring-alert
       - name: multiple
         location: examples/multiple
       - name: pubsub
@@ -139,16 +141,12 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/secretmanager.admin
-          - roles/cloudkms.admin
-          - roles/pubsub.admin
+          - roles/logging.logWriter
+          - roles/secretmanager.secretAccessor
+          - roles/secretmanager.secretVersionAdder
+          - roles/secretmanager.viewer
     services:
-      - cloudresourcemanager.googleapis.com
-      - storage-api.googleapis.com
-      - serviceusage.googleapis.com
       - secretmanager.googleapis.com
-      - pubsub.googleapis.com
-      - cloudkms.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 4.83.0, < 7"

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -17,9 +17,9 @@
 locals {
   per_module_roles = {
     simple-secret = [
-      "roles/secretmanager.secretAccessor",
-      "roles/secretmanager.secretVersionAdder",
-      "roles/secretmanager.viewer",
+      "roles/secretmanager.admin",
+      "roles/cloudkms.admin",
+      "roles/pubsub.admin",
       "roles/logging.logWriter"
     ]
     root = [

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -15,13 +15,26 @@
  */
 
 locals {
-  int_required_roles = [
+  per_module_roles = {
+    simple-secret = [
+      "roles/secretmanager.secretAccessor",
+      "roles/secretmanager.secretVersionAdder",
+      "roles/secretmanager.viewer",
+      "roles/logging.logWriter"
+    ]
+    root = [
+      "roles/secretmanager.admin",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter"
+    ]
+  }
+  int_required_roles = concat([
     "roles/secretmanager.admin",
     "roles/cloudkms.admin",
     "roles/pubsub.admin",
     "roles/monitoring.admin",
     "roles/logging.admin",
-  ]
+  ], flatten(values(local.per_module_roles)))
 }
 
 resource "google_service_account" "int_test" {

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -13,6 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+locals {
+  per_module_services = {
+    simple-secret = [
+      "secretmanager.googleapis.com"
+    ]
+    root = [
+      "secretmanager.googleapis.com",
+      "iam.googleapis.com"
+    ]
+  }
+}
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
@@ -24,7 +35,7 @@ module "project" {
   folder_id         = var.folder_id
   billing_account   = var.billing_account
 
-  activate_apis = [
+  activate_apis = concat([
     "cloudresourcemanager.googleapis.com",
     "storage-api.googleapis.com",
     "serviceusage.googleapis.com",
@@ -33,5 +44,5 @@ module "project" {
     "cloudkms.googleapis.com",
     "monitoring.googleapis.com",
     "logging.googleapis.com"
-  ]
+  ], flatten(values(local.per_module_services)))
 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -16,7 +16,9 @@
 locals {
   per_module_services = {
     simple-secret = [
-      "secretmanager.googleapis.com"
+      "secretmanager.googleapis.com",
+      "pubsub.googleapis.com",
+      "cloudkms.googleapis.com",
     ]
     root = [
       "secretmanager.googleapis.com",


### PR DESCRIPTION
Introduced:

- per_module_roles: to config required roles to run each sub modules.
- per_module_service: to config required services to run each sub modules.

Added feature flag `--per-module-requirements` to generate_docs cmd, to align with the per module configs.