### PR TITLE
feat: add regional-secret submodule with example and integration test

### DIFF
--- a/examples/regional-secret/README.md
+++ b/examples/regional-secret/README.md
@@ -1,0 +1,33 @@
+# Regional secret example
+
+This example creates a regional secret in Google Cloud Secret Manager, with:
+
+- A regional KMS key used for customer-managed encryption (CMEK) — co-located with the secret
+- A Pub/Sub topic for rotation notifications, with the Secret Manager service identity granted `roles/pubsub.publisher`
+- A `time_sleep` to wait for the Secret Manager service identity to propagate before granting it KMS access
+- Authoritative IAM bindings on the secret for two distinct roles, demonstrating the `iam_bindings` map
+
+## Note
+
+If you manage any sensitive data with Terraform (database passwords, user passwords, private keys), treat the state itself as sensitive data. Storing state remotely can provide better security.
+
+See: https://developer.hashicorp.com/terraform/language/state/sensitive-data
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| location | The location (region) of the Secret Manager resources. | `string` | `"us-central1"` | no |
+| project\_id | The project ID to manage the Secret Manager resources. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| location | The location (region) of the regional secret. |
+| secret\_id | The short secret\_id of the regional secret. |
+| secret\_name | The fully-qualified name of the regional secret. |
+| secret\_version | The fully-qualified name of the secret version. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/regional-secret/main.tf
+++ b/examples/regional-secret/main.tf
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "random_id" "random_suffix" {
+  byte_length = 2
+}
+
+# --- KMS key (must live in the same region as the secret) -------------------
+
+resource "google_kms_key_ring" "key_ring" {
+  name     = "key-ring-${random_id.random_suffix.hex}"
+  location = var.location
+  project  = var.project_id
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  name     = "crypto-key-${random_id.random_suffix.hex}"
+  key_ring = google_kms_key_ring.key_ring.id
+}
+
+# --- Secret Manager service identity ----------------------------------------
+
+resource "google_project_service_identity" "secretmanager_identity" {
+  provider = google-beta
+  project  = var.project_id
+  service  = "secretmanager.googleapis.com"
+}
+
+resource "time_sleep" "wait_service_identity_propagation" {
+  depends_on      = [google_project_service_identity.secretmanager_identity]
+  create_duration = "60s"
+}
+
+resource "google_kms_crypto_key_iam_member" "sm_sa_encrypter_decrypter" {
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${google_project_service_identity.secretmanager_identity.email}"
+  crypto_key_id = google_kms_crypto_key.crypto_key.id
+  depends_on    = [time_sleep.wait_service_identity_propagation]
+}
+
+# --- Pub/Sub topic for rotation notifications -------------------------------
+
+resource "google_pubsub_topic" "secret" {
+  project = var.project_id
+  name    = "topic-${random_id.random_suffix.hex}"
+}
+
+resource "google_pubsub_topic_iam_member" "sm_sa_publisher" {
+  project = var.project_id
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:${google_project_service_identity.secretmanager_identity.email}"
+  topic   = google_pubsub_topic.secret.name
+}
+
+# --- Regional secret --------------------------------------------------------
+
+module "regional-secret" {
+  source = "../../modules/regional-secret"
+
+  project_id  = var.project_id
+  name        = "regional-secret-${random_id.random_suffix.hex}"
+  location    = var.location
+  secret_data = "secret information"
+
+  labels = {
+    label = "my-label"
+  }
+
+  annotations = {
+    description = "Regional secret example with CMEK, rotation and granular IAM"
+    owner       = "platform-team"
+  }
+
+  customer_managed_encryption = {
+    kms_key_name = google_kms_crypto_key.crypto_key.id
+  }
+
+  topics = [google_pubsub_topic.secret.id]
+
+  rotation = {
+    next_rotation_time = "2030-01-01T00:00:01Z"
+    rotation_period    = "31536000s"
+  }
+
+  iam_bindings = {
+    "roles/secretmanager.secretAccessor" = [
+      "serviceAccount:${google_project_service_identity.secretmanager_identity.email}",
+    ]
+    "roles/secretmanager.viewer" = [
+      "serviceAccount:${google_project_service_identity.secretmanager_identity.email}",
+    ]
+  }
+
+  depends_on = [
+    google_kms_crypto_key_iam_member.sm_sa_encrypter_decrypter,
+    google_pubsub_topic_iam_member.sm_sa_publisher,
+  ]
+}

--- a/examples/regional-secret/outputs.tf
+++ b/examples/regional-secret/outputs.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "secret_id" {
+  value       = module.regional-secret.secret_id
+  description = "The short secret_id of the regional secret."
+}
+
+output "secret_name" {
+  value       = module.regional-secret.name
+  description = "The fully-qualified name of the regional secret."
+}
+
+output "secret_version" {
+  value       = module.regional-secret.version
+  description = "The fully-qualified name of the secret version."
+}
+
+output "location" {
+  value       = module.regional-secret.location
+  description = "The location (region) of the regional secret."
+}

--- a/examples/regional-secret/variables.tf
+++ b/examples/regional-secret/variables.tf
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type        = string
+  description = "The project ID to manage the Secret Manager resources."
+}
+
+variable "location" {
+  type        = string
+  description = "The location (region) of the Secret Manager resources."
+  default     = "us-central1"
+}

--- a/modules/regional-secret/README.md
+++ b/modules/regional-secret/README.md
@@ -1,0 +1,154 @@
+# Terraform Google Regional Secret Manager Submodule
+
+This module creates a single Google Cloud **regional** Secret Manager secret (using the `google_secret_manager_regional_secret*` resources, which target the regional API endpoint `secretmanager.<location>.rep.googleapis.com`). It supports CMEK, Pub/Sub topic notifications, rotation, version delayed-destruction, deletion protection, version aliases and authoritative IAM bindings indexed by role.
+
+A regional secret is bound to a single GCP region and cannot be replicated, in contrast with the global secrets handled by the root module and the [`simple-secret`](../simple-secret/) submodule.
+
+## Usage
+
+Basic usage of this module is as follows:
+
+```hcl
+module "regional-secret" {
+  source  = "GoogleCloudPlatform/secret-manager/google//modules/regional-secret"
+  version = "~> 0.9"
+
+  project_id  = var.project_id
+  name        = "my-regional-secret"
+  location    = "europe-west1"
+  secret_data = "secret information"
+}
+```
+
+With CMEK, Pub/Sub notifications, rotation, annotations and authoritative IAM:
+
+```hcl
+module "regional-secret" {
+  source  = "GoogleCloudPlatform/secret-manager/google//modules/regional-secret"
+  version = "~> 0.9"
+
+  project_id  = var.project_id
+  name        = "db-prod"
+  location    = "europe-west1"
+  secret_data = var.db_password
+
+  annotations = {
+    description = "Production database password"
+    owner       = "platform-team"
+  }
+
+  customer_managed_encryption = {
+    kms_key_name = google_kms_crypto_key.secret_key.id
+  }
+
+  topics = [google_pubsub_topic.secret_events.id]
+
+  rotation = {
+    next_rotation_time = "2030-01-01T00:00:00Z"
+    rotation_period    = "31536000s"
+  }
+
+  iam_bindings = {
+    "roles/secretmanager.secretAccessor" = [
+      "group:sre@example.com",
+      "serviceAccount:app@${var.project_id}.iam.gserviceaccount.com",
+    ]
+    "roles/secretmanager.viewer" = [
+      "group:devs@example.com",
+    ]
+  }
+}
+```
+
+A complete example that also provisions the KMS key and Pub/Sub topic is available in [`examples/regional-secret`](../../examples/regional-secret).
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| annotations | Free-form annotations on the secret (max 16KiB total). Useful for metadata such as a description, e.g. `{ description = "DB password (prod)" }`. | `map(string)` | `{}` | no |
+| create\_version | Whether to create a secret version with `secret_data`. If false (or `secret_data` is null), no version is created. | `bool` | `true` | no |
+| customer\_managed\_encryption | Customer-managed encryption configuration. The KMS key MUST be located in the same region as the secret.<br>Example:<br>  customer\_managed\_encryption = {<br>    kms\_key\_name = "projects/PROJECT\_ID/locations/LOCATION/keyRings/KEY\_RING/cryptoKeys/KEY"<br>  }<br>If null, Google-managed encryption is used. | <pre>object({<br>    kms_key_name = string<br>  })</pre> | `null` | no |
+| deletion\_protection | If true, Terraform will refuse to destroy the secret. Must be disabled before a destroy can succeed. | `bool` | `false` | no |
+| expire\_time | RFC3339 timestamp at which the secret is automatically deleted. Mutually exclusive with `ttl`. | `string` | `null` | no |
+| iam\_bindings | Authoritative IAM bindings on the secret, indexed by role. Each role's full member list is set authoritatively (any member granted that role outside Terraform will be removed on apply).<br>Example:<br>  iam\_bindings = {<br>    "roles/secretmanager.secretAccessor" = ["group:sre@example.com", "user:dev1@example.com"]<br>    "roles/secretmanager.viewer"         = ["group:devs@example.com"]<br>  } | `map(list(string))` | `{}` | no |
+| labels | The map of labels to be added to the secret. | `map(string)` | `{}` | no |
+| location | The location (region) of the Secret Manager resources, e.g. "europe-west1". A regional secret is bound to a single region and cannot be replicated. | `string` | n/a | yes |
+| name | The name (secret\_id) of the regional secret to create. | `string` | n/a | yes |
+| project\_id | The project ID to manage the Secret Manager resources. | `string` | n/a | yes |
+| rotation | Rotation policy for the secret. Notifications are published to `topics`. If null, the secret will not rotate. | <pre>object({<br>    next_rotation_time = optional(string)<br>    rotation_period    = optional(string)<br>  })</pre> | `null` | no |
+| secret\_data | The secret data. Must be no larger than 64KiB. If null, no secret version is created (useful when the value is managed elsewhere). Note: this property is sensitive and will not be displayed in the plan. | `string` | `null` | no |
+| topics | List of up to 10 Pub/Sub topic IDs to which messages are published when control plane operations are performed on the secret. The topics MUST exist before the secret is created and the Secret Manager service identity MUST have `roles/pubsub.publisher` on them. | `list(string)` | `[]` | no |
+| ttl | Duration after which the secret is automatically deleted, e.g. "2592000s". Mutually exclusive with `expire_time`. | `string` | `null` | no |
+| version\_aliases | Mapping from human-readable alias to version number, e.g. `{ "production" = "1" }`. | `map(string)` | `{}` | no |
+| version\_destroy\_ttl | Secret version TTL after destruction request, e.g. "86400s". When set, destroyed versions transition to a disabled state and are actually destroyed after this TTL. Null disables this behavior. | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| env\_vars | Secret as environment variable, in the same shape as the simple-secret submodule. |
+| id | The full resource ID of the regional secret. |
+| location | The location (region) of the regional secret. |
+| name | The fully-qualified name of the regional secret (projects/<project>/locations/<location>/secrets/<name>). |
+| project\_id | GCP project ID where the regional secret was created. |
+| secret\_id | The short secret\_id of the regional secret. |
+| version | Fully-qualified name of the created secret version (or null if no version was created). |
+| version\_id | Short version number of the created secret version (or null if no version was created). |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Requirements
+
+These sections describe requirements for using this module.
+
+### Software
+
+The following dependencies must be available:
+
+- [Terraform][terraform] v1.3+
+- [Terraform Provider for GCP][terraform-provider-gcp] plugin v5.10+ (regional Secret Manager resources are GA from this version)
+
+### Service Account
+
+A service account with the following roles must be used to provision the resources of this module:
+
+- Secret Manager Admin: `roles/secretmanager.admin`
+
+If the IAM bindings are managed by this module, the service account also needs:
+
+- Secret Manager Admin (`roles/secretmanager.admin`) is sufficient to manage IAM on the secret.
+
+If the secret uses CMEK or Pub/Sub topics, the **Secret Manager service identity** (`service-<project-number>@gcp-sa-secretmanager.iam.gserviceaccount.com`) must have:
+
+- `roles/cloudkms.cryptoKeyEncrypterDecrypter` on the KMS key
+- `roles/pubsub.publisher` on each Pub/Sub topic
+
+These IAM grants are intentionally **not** managed by this module — they belong to the consumer or to a dedicated bootstrap module. See [`examples/regional-secret`](../../examples/regional-secret) for an end-to-end setup.
+
+### APIs
+
+A project with the following APIs enabled must be used to host the resources of this module:
+
+- Secret Manager API: `secretmanager.googleapis.com`
+
+The [Project Factory module][project-factory-module] can be used to provision a project with the necessary APIs enabled.
+
+## IAM model
+
+`iam_bindings` is **authoritative per role**. For each role passed in the map, this module manages the *entire* member list — any member granted that same role through another mechanism will be removed at the next `terraform apply`. Roles not listed in `iam_bindings` are left untouched.
+
+If you need additive (non-authoritative) IAM, consider using `google_secret_manager_regional_secret_iam_member` resources outside this module on top of (or instead of) the `iam_bindings` provided here.
+
+## Contributing
+
+Refer to the [contribution guidelines](../../CONTRIBUTING.md) for information on contributing to this module.
+
+[project-factory-module]: https://registry.terraform.io/modules/terraform-google-modules/project-factory/google
+[terraform-provider-gcp]: https://www.terraform.io/docs/providers/google/index.html
+[terraform]: https://www.terraform.io/downloads.html
+
+## Security Disclosures
+
+Please see our [security disclosure process](../../SECURITY.md).

--- a/modules/regional-secret/main.tf
+++ b/modules/regional-secret/main.tf
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**********************************************************
+  Regional Secret Manager Secret, Version and IAM bindings
+ **********************************************************/
+
+locals {
+  secret_name_parts = split("/", try(google_secret_manager_regional_secret_version.version[0].name, ""))
+  secret_version    = length(local.secret_name_parts) > 0 ? element(local.secret_name_parts, length(local.secret_name_parts) - 1) : ""
+}
+
+resource "google_secret_manager_regional_secret" "secret" {
+  project   = var.project_id
+  secret_id = var.name
+  location  = var.location
+
+  labels      = var.labels
+  annotations = var.annotations
+
+  dynamic "customer_managed_encryption" {
+    for_each = var.customer_managed_encryption != null ? [var.customer_managed_encryption] : []
+    content {
+      kms_key_name = customer_managed_encryption.value.kms_key_name
+    }
+  }
+
+  dynamic "topics" {
+    for_each = var.topics
+    content {
+      name = topics.value
+    }
+  }
+
+  dynamic "rotation" {
+    for_each = var.rotation != null ? [var.rotation] : []
+    content {
+      next_rotation_time = rotation.value.next_rotation_time
+      rotation_period    = rotation.value.rotation_period
+    }
+  }
+
+  version_aliases     = var.version_aliases
+  version_destroy_ttl = var.version_destroy_ttl
+  expire_time         = var.expire_time
+  ttl                 = var.ttl
+  deletion_protection = var.deletion_protection
+}
+
+resource "google_secret_manager_regional_secret_version" "version" {
+  count = var.create_version && var.secret_data != null ? 1 : 0
+
+  secret      = google_secret_manager_regional_secret.secret.id
+  secret_data = var.secret_data
+}
+
+resource "google_secret_manager_regional_secret_iam_binding" "bindings" {
+  for_each = var.iam_bindings
+
+  project   = var.project_id
+  location  = var.location
+  secret_id = google_secret_manager_regional_secret.secret.secret_id
+
+  role    = each.key
+  members = each.value
+}

--- a/modules/regional-secret/outputs.tf
+++ b/modules/regional-secret/outputs.tf
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "id" {
+  description = "The full resource ID of the regional secret."
+  value       = google_secret_manager_regional_secret.secret.id
+}
+
+output "name" {
+  description = "The fully-qualified name of the regional secret (projects/<project>/locations/<location>/secrets/<name>)."
+  value       = google_secret_manager_regional_secret.secret.name
+}
+
+output "secret_id" {
+  description = "The short secret_id of the regional secret."
+  value       = google_secret_manager_regional_secret.secret.secret_id
+}
+
+output "location" {
+  description = "The location (region) of the regional secret."
+  value       = google_secret_manager_regional_secret.secret.location
+}
+
+output "project_id" {
+  description = "GCP project ID where the regional secret was created."
+  value       = google_secret_manager_regional_secret.secret.project
+}
+
+output "version" {
+  description = "Fully-qualified name of the created secret version (or null if no version was created)."
+  value       = try(google_secret_manager_regional_secret_version.version[0].name, null)
+}
+
+output "version_id" {
+  description = "Short version number of the created secret version (or null if no version was created)."
+  value       = local.secret_version != "" ? local.secret_version : null
+}
+
+output "env_vars" {
+  description = "Secret as environment variable, in the same shape as the simple-secret submodule."
+  value       = { "SECRET" : { secret : var.name, version : local.secret_version } }
+}

--- a/modules/regional-secret/variables.tf
+++ b/modules/regional-secret/variables.tf
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The project ID to manage the Secret Manager resources."
+  type        = string
+}
+
+variable "name" {
+  description = "The name (secret_id) of the regional secret to create."
+  type        = string
+}
+
+variable "location" {
+  description = "The location (region) of the Secret Manager resources, e.g. \"europe-west1\". A regional secret is bound to a single region and cannot be replicated."
+  type        = string
+}
+
+variable "secret_data" {
+  description = "The secret data. Must be no larger than 64KiB. If null, no secret version is created (useful when the value is managed elsewhere). Note: this property is sensitive and will not be displayed in the plan."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "create_version" {
+  description = "Whether to create a secret version with `secret_data`. If false (or `secret_data` is null), no version is created."
+  type        = bool
+  default     = true
+}
+
+variable "labels" {
+  description = "The map of labels to be added to the secret."
+  type        = map(string)
+  default     = {}
+}
+
+variable "annotations" {
+  description = "Free-form annotations on the secret (max 16KiB total). Useful for metadata such as a description, e.g. `{ description = \"DB password (prod)\" }`."
+  type        = map(string)
+  default     = {}
+}
+
+variable "customer_managed_encryption" {
+  description = <<-EOT
+    Customer-managed encryption configuration. The KMS key MUST be located in the same region as the secret.
+    Example:
+      customer_managed_encryption = {
+        kms_key_name = "projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY"
+      }
+    If null, Google-managed encryption is used.
+  EOT
+  type = object({
+    kms_key_name = string
+  })
+  default = null
+}
+
+variable "topics" {
+  description = "List of up to 10 Pub/Sub topic IDs to which messages are published when control plane operations are performed on the secret. The topics MUST exist before the secret is created and the Secret Manager service identity MUST have `roles/pubsub.publisher` on them."
+  type        = list(string)
+  default     = []
+}
+
+variable "rotation" {
+  description = "Rotation policy for the secret. Notifications are published to `topics`. If null, the secret will not rotate."
+  type = object({
+    next_rotation_time = optional(string)
+    rotation_period    = optional(string)
+  })
+  default = null
+}
+
+variable "version_aliases" {
+  description = "Mapping from human-readable alias to version number, e.g. `{ \"production\" = \"1\" }`."
+  type        = map(string)
+  default     = {}
+}
+
+variable "version_destroy_ttl" {
+  description = "Secret version TTL after destruction request, e.g. \"86400s\". When set, destroyed versions transition to a disabled state and are actually destroyed after this TTL. Null disables this behavior."
+  type        = string
+  default     = null
+}
+
+variable "expire_time" {
+  description = "RFC3339 timestamp at which the secret is automatically deleted. Mutually exclusive with `ttl`."
+  type        = string
+  default     = null
+}
+
+variable "ttl" {
+  description = "Duration after which the secret is automatically deleted, e.g. \"2592000s\". Mutually exclusive with `expire_time`."
+  type        = string
+  default     = null
+}
+
+variable "deletion_protection" {
+  description = "If true, Terraform will refuse to destroy the secret. Must be disabled before a destroy can succeed."
+  type        = bool
+  default     = false
+}
+
+variable "iam_bindings" {
+  description = <<-EOT
+    Authoritative IAM bindings on the secret, indexed by role. Each role's full member list is set authoritatively (any member granted that role outside Terraform will be removed on apply).
+    Example:
+      iam_bindings = {
+        "roles/secretmanager.secretAccessor" = ["group:sre@example.com", "user:dev1@example.com"]
+        "roles/secretmanager.viewer"         = ["group:devs@example.com"]
+      }
+  EOT
+  type        = map(list(string))
+  default     = {}
+}

--- a/modules/regional-secret/versions.tf
+++ b/modules/regional-secret/versions.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 1.3"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.10, < 8"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-secret-manager:regional-secret/v0.9.0"
+  }
+}

--- a/test/integration/regional-secret/regional_secret_test.go
+++ b/test/integration/regional-secret/regional_secret_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regional_secret
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+const regionalSecretLocation = "us-central1"
+
+func TestRegionalSecret(t *testing.T) {
+	secretT := tft.NewTFBlueprintTest(t)
+
+	secretT.DefineVerify(func(assert *assert.Assertions) {
+		secretT.DefaultVerify(assert)
+
+		projectID := secretT.GetTFSetupStringOutput("project_id")
+		projectDescribe := gcloud.Runf(t, "projects describe %s", projectID)
+		projectNumber := projectDescribe.Get("projectNumber").String()
+
+		fullSecretName := secretT.GetStringOutput("secret_name")
+		parts := strings.Split(fullSecretName, "/")
+		secretID := parts[len(parts)-1]
+
+		baseURL := fmt.Sprintf(
+			"https://secretmanager.%s.rep.googleapis.com/v1/projects/%s/locations/%s/secrets/%s",
+			regionalSecretLocation, projectID, regionalSecretLocation, secretID,
+		)
+
+		// --- Secret describe ---
+		secret, err := getJSON(t, baseURL)
+		if err != nil {
+			assert.FailNow("failed to GET regional secret", err)
+		}
+
+		assert.Equal(
+			fmt.Sprintf("projects/%s/locations/%s/secrets/%s", projectNumber, regionalSecretLocation, secretID),
+			secret.Get("name").String(),
+			"secret has expected fully-qualified name",
+		)
+		assert.Equal("my-label", secret.Get("labels.label").String(), "secret has expected label")
+		assert.Equal(
+			"Regional secret example with CMEK, rotation and granular IAM",
+			secret.Get("annotations.description").String(),
+			"secret has expected description annotation",
+		)
+		assert.Equal("platform-team", secret.Get("annotations.owner").String(), "secret has expected owner annotation")
+
+		topic := secret.Get("topics.0.name").String()
+		assert.True(
+			strings.HasPrefix(topic, fmt.Sprintf("projects/%s/topics/", projectID)),
+			"secret has at least one topic in the expected project: %s", topic,
+		)
+
+		assert.Equal("2030-01-01T00:00:01Z", secret.Get("rotation.nextRotationTime").String(), "rotation next time matches")
+		assert.Equal("31536000s", secret.Get("rotation.rotationPeriod").String(), "rotation period matches")
+
+		kmsKey := secret.Get("customerManagedEncryption.kmsKeyName").String()
+		assert.True(
+			strings.HasPrefix(kmsKey, fmt.Sprintf("projects/%s/locations/%s/keyRings/", projectID, regionalSecretLocation)),
+			"CMEK key is in the same project and region: %s", kmsKey,
+		)
+
+		// --- Secret version describe ---
+		secretVersion, err := getJSON(t, fmt.Sprintf("%s/versions/1", baseURL))
+		if err != nil {
+			assert.FailNow("failed to GET regional secret version", err)
+		}
+		assert.Equal(
+			fmt.Sprintf("projects/%s/locations/%s/secrets/%s/versions/1", projectNumber, regionalSecretLocation, secretID),
+			secretVersion.Get("name").String(),
+			"secret version has expected name",
+		)
+		assert.Equal("ENABLED", secretVersion.Get("state").String(), "secret version is ENABLED")
+
+		// --- IAM policy ---
+		iamPolicy, err := getJSON(t, fmt.Sprintf("%s:getIamPolicy", baseURL))
+		if err != nil {
+			assert.FailNow("failed to GET regional secret IAM policy", err)
+		}
+
+		expectedRoles := map[string]bool{
+			"roles/secretmanager.secretAccessor": false,
+			"roles/secretmanager.viewer":         false,
+		}
+		smIdentity := fmt.Sprintf(
+			"serviceAccount:service-%s@gcp-sa-secretmanager.iam.gserviceaccount.com",
+			projectNumber,
+		)
+		for _, b := range iamPolicy.Get("bindings").Array() {
+			role := b.Get("role").String()
+			if _, ok := expectedRoles[role]; !ok {
+				continue
+			}
+			expectedRoles[role] = true
+			members := b.Get("members").Array()
+			found := false
+			for _, m := range members {
+				if m.String() == smIdentity {
+					found = true
+					break
+				}
+			}
+			assert.True(found, "role %s should include the Secret Manager service identity", role)
+		}
+		for role, seen := range expectedRoles {
+			assert.True(seen, "expected role %s to be configured on the secret", role)
+		}
+	})
+	secretT.Test()
+}
+
+func getJSON(t *testing.T, url string) (*gjson.Result, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	token := gcloud.Run(t, "auth print-access-token").Get("token").String()
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("HTTP %s on %s: %s", resp.Status, url, string(body))
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	parsed := gjson.ParseBytes(body)
+	return &parsed, nil
+}


### PR DESCRIPTION
## Summary

Adds a new `modules/regional-secret` submodule that creates a single Google Cloud **regional** Secret Manager secret (using the `google_secret_manager_regional_secret*` resources, which target the regional API endpoint `secretmanager.<location>.rep.googleapis.com`), along with an optional version and authoritative IAM bindings indexed by role.

Inspired by the closed upstream [#133](https://github.com/GoogleCloudPlatform/terraform-google-secret-manager/pull/133) but reworked to be **atomic per-secret** (Terragrunt-friendly: callers loop with their own DSL), and with **granular IAM** via a `map<role, list<members>>` instead of a single accessor list.

## Features

The submodule exposes the full surface of the regional Secret Manager API:

- `customer_managed_encryption` (CMEK, must be regionally co-located)
- `topics` (Pub/Sub notifications)
- `rotation` (`next_rotation_time`, `rotation_period`)
- `version_aliases`
- `version_destroy_ttl` (delayed destruction, parity with what was just added on the global module in #138)
- `expire_time` / `ttl` (mutually exclusive — left to the API to validate)
- `deletion_protection`
- `labels` and free-form `annotations` (the API has no `description` field — annotations are the standard substitute)
- `iam_bindings = map<role, list<members>>` — authoritative per role (uses `google_secret_manager_regional_secret_iam_binding`)

The Secret Manager service identity / KMS / Pub/Sub IAM grants are **not** managed by this submodule — they are the consumer's responsibility, which keeps the module atomic and consistent with `simple-secret`. The example demonstrates the end-to-end setup.

## Files

- `modules/regional-secret/{versions,variables,main,outputs}.tf` + `README.md`
- `examples/regional-secret/{main,variables,outputs}.tf` + `README.md` — KMS keyring + crypto key, Secret Manager service identity, Pub/Sub topic, all wired up to the secret with CMEK, rotation, annotations and two distinct IAM roles.
- `test/integration/regional-secret/regional_secret_test.go` — verifies via the regional API endpoint: secret name, labels, annotations, topics, rotation, CMEK, version state, and the IAM policy bindings.

## Test plan

- [x] `terraform fmt -recursive`
- [x] `terraform validate` on the submodule
- [x] `terraform validate` on the example
- [ ] `terraform plan` / `terraform apply` against a sandbox project (to be run by reviewer or contributor)
- [ ] Integration test (`go test ./test/integration/regional-secret/...`) against a sandbox project
- [ ] CI lint workflow passes

## Notes

- Provider constraint is `hashicorp/google >= 5.10, < 8` — `google_secret_manager_regional_secret*` is GA from provider v5.10. No `google-beta` dependency in the submodule itself.
- Drafted PR — opened for early review and to validate the API surface before running end-to-end tests on a sandbox project.